### PR TITLE
Enable okcomputer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ rerun.txt
 pickle-email-*.html
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
-config/initializers/secret_token.rb
+/config/initializers/secret_token.rb
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 gem 'hyrax', '2.1.0.rc1'
 
 gem 'sidekiq'
+gem 'okcomputer'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,6 +501,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    okcomputer (1.17.2)
     om (3.1.1)
       activemodel
       activesupport
@@ -789,6 +790,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  okcomputer
   puma (~> 3.7)
   rails (~> 5.1.6)
   riiif (~> 1.1)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,8 @@
+# config/initializers/okcomputer.rb
+
+  if ENV["OKCOMPUTER_PASSWD"].present?
+    OkComputer.require_authentication("status", ENV["OKCOMPUTER_PASSWD"])
+  end
+
+
+


### PR DESCRIPTION
uses an environment variable (set in the dotenv production or development file): OKCOMPUTER_PASSWD, assumes a user name of "status"